### PR TITLE
Add execution user to messages of onsuccess/onfailure

### DIFF
--- a/src/SimpleSlackNotification.groovy
+++ b/src/SimpleSlackNotification.groovy
@@ -41,12 +41,12 @@ rundeckPlugin(NotificationPlugin) {
     }
 
     onsuccess { Map execution, Map configuration ->
-        notify(configuration, "<${execution.href}|${execution.job.name}> *succeeded* :sunny:")
+        notify(configuration, "${execution.user} <${execution.href}|${execution.job.name}> *succeeded* :sunny:")
         true
     }
 
     onfailure { Map execution, Map configuration ->
-        notify(configuration, "<${execution.href}|${execution.job.name}> *failed* :umbrella:")
+        notify(configuration, "${execution.user} <${execution.href}|${execution.job.name}> *failed* :umbrella:")
         true
     }
 }


### PR DESCRIPTION
Add execution user name to messages of onsuccess and onfailure.
![image](https://user-images.githubusercontent.com/1213991/69430867-ddb43480-0d79-11ea-8297-d9f8919cdf3b.png)
